### PR TITLE
[Feature] Show time diff instead of exact arrival time

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,12 +5,13 @@
  */
 !process.env.SKIP_ENV_VALIDATION && (await import("./src/env/server.mjs"));
 
-import pwa from "next-pwa"
+import pwa from "next-pwa";
 
 const withPWA = pwa({
   dest: "public",
   register: true,
   skipWaiting: true,
+  mode: "production",
 });
 
 /** @type {import('next').NextConfig} */

--- a/src/components/departure-card.tsx
+++ b/src/components/departure-card.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import type { Departure } from "@server/trpc/models/departure";
 import { formatTimeHHMM } from "@utils/format-time";
 import { DelayText } from "./delay-text";
+import { formatMinDiffToNow } from "@utils/format-min-diff-to-now";
 
 interface Props {
     departure: Departure
@@ -21,12 +22,11 @@ export function DepartureCard(props: Props): React.ReactElement {
 
     return (
         <Link className="bg-white rounded-md w-11/12 md:w-1/2 py-3 px-2 my-2 flex flex-row gap-2" href={`/trip/${stationId}/${departure.id}/${departure.lineName}`}>
-
             <span className={`px-2 py-2 h-12 w-12 ${lineNameTextColor} text-center text-xl rounded-lg bg-${departure.lineName.toLowerCase()}`}>{departure.lineName}</span>
             <div className="flex flex-col overflow-hidden">
                 <p className="font-thin text-lg overflow-hidden whitespace-nowrap text-ellipsis">{departure.direction}</p>
                 <div className="flex flex-row gap-3">
-                    <p className="font-bold text-md">{formatTimeHHMM(departure.when)}</p>
+                    <p className="font-bold text-md">{formatMinDiffToNow(departure.when)}</p>
                     <DelayText delay={departure.delay} />
                 </div>
             </div>

--- a/src/utils/format-min-diff-to-now.ts
+++ b/src/utils/format-min-diff-to-now.ts
@@ -1,0 +1,9 @@
+import { formatMinDiff } from "./format-min-diff";
+
+export function formatMinDiffToNow(date: Date): string {
+    const now = new Date();
+
+    const diff = Math.round((date.getTime() - now.getTime()) / 60000);
+
+    return formatMinDiff(diff);
+}

--- a/src/utils/format-min-diff.ts
+++ b/src/utils/format-min-diff.ts
@@ -1,0 +1,9 @@
+const formatter = new Intl.RelativeTimeFormat('en', { style: "narrow" });
+
+export function formatMinDiff(minDiff: number): string {
+    if (minDiff === 0) {
+        return "now";
+    }
+
+    return formatter.format(minDiff, "minutes");
+}


### PR DESCRIPTION
- In departures screen show arrival as time diff instead of an exact point of time

Advantages: 
 - easier to understand
 - makes it clearer that times are only accurate to the minute not seconds